### PR TITLE
Change "saveDev" to correct npm syntax "save-dev"

### DIFF
--- a/documentation/src/views/index.html
+++ b/documentation/src/views/index.html
@@ -33,7 +33,7 @@ fabricator: true
 	<h4><em>In a hurry? Clone <a class="link" href="https://github.com/VinSpee/shed-starter">this repo</a> to get going with a starter kit and skip all of the setup.</em></h4>
 
 	<h3>First, install shed using <a href="http://www.nearform.com/nodecrunch/nodejs-sudo-free/" class="link">npm</a>.</h3>
-	<pre class="language-bash"><code class="language-bash">❯ npm install --saveDev shed-css</code></pre>
+	<pre class="language-bash"><code class="language-bash">❯ npm install --save-dev shed-css</code></pre>
 
 	<p class="m-b:7">At this point, we come to a fork in the road. Choose one of these options:</p>
 


### PR DESCRIPTION
As a user and an implicit rule follower, I would want the correct install commands in Shed's documentation, so I don't use the incorrect commands while trying to follow documentation.