### PR TITLE
Fix invalid syntax in negative-value classes

### DIFF
--- a/src/lib/sides.css
+++ b/src/lib/sides.css
@@ -24,7 +24,7 @@
 				}
 
 				.$(pos)\:-$(z) {
-					$(pos): -var(--z$(ms));
+					$(pos): calc(0px - var(--z$(ms)));
 				}
 			}
 		} @else {
@@ -48,7 +48,7 @@
 					}
 
 					.$(pos)\:-$(z)\@$(mq) {
-						$(pos): -var(--z$(ms));
+						$(pos): calc(0px - var(--z$(ms)));
 					}
 				}
 			}

--- a/src/lib/space.css
+++ b/src/lib/space.css
@@ -49,8 +49,8 @@
 							}
 							@if $(prop) == margin {
 								.$(short)-$(dir-short)\:-$(z) {
-									$(prop)-left: -var(--z$(ms));
-									$(prop)-right: -var(--z$(ms));
+									$(prop)-left: calc(0px - var(--z$(ms)));
+									$(prop)-right: calc(0px - var(--z$(ms)));
 								}
 							}
 						} @else if $(dir) == y {
@@ -60,8 +60,8 @@
 							}
 							@if $(prop) == margin {
 								.$(short)-$(dir-short)\:-$(z) {
-									$(prop)-top: -var(--z$(ms));
-									$(prop)-bottom: -var(--z$(ms));
+									$(prop)-top: calc(0px - var(--z$(ms)));
+									$(prop)-bottom: calc(0px - var(--z$(ms)));
 								}
 							}
 						} @else {
@@ -70,7 +70,7 @@
 							}
 							@if $(prop) == margin {
 								.$(short)-$(dir-short)\:-$(z) {
-									$(prop)-$(dir): -var(--z$(ms));
+									$(prop)-$(dir): calc(0px - var(--z$(ms)));
 								}
 							}
 						}
@@ -115,7 +115,7 @@
 							}
 							@if $(prop) == margin {
 								.$(short)\:-$(z)\@$(mq) {
-									$(prop): -var(--z$(ms));
+									$(prop): calc(0px - var(--z$(ms)));
 								}
 							}
 						} @else {
@@ -144,7 +144,7 @@
 								}
 								@if $(prop) == margin {
 									.$(short)-$(dir-short)\:-$(z)\@$(mq) {
-										$(prop)-$(dir): -var(--z$(ms));
+										$(prop)-$(dir): calc(0px - var(--z$(ms)));
 									}
 								}
 							}


### PR DESCRIPTION
Working in a project that requires PostCSS 6+ and other updated build dependencies I noticed that output for some of Shed's negative-value classes (e.g. `m-t:-8`) was broken.

Turns out these classes have invalid syntax; I assume they only worked with older versions of Shed's PostCSS build dependencies because of incomplete support for CSS specs. I poked around a bit trying to work out exactly what had changed, thinking maybe updates to `postcss-custom-properties` or `postcss-calc` had led to the different output, but wasn't able to pin it down.

#### Why calc?
Per CSS specs, the `var()` function can only be used in place of a complete value; partial value replacements like `-var()` are invalid. This PR introduces `calc()` as a workaround, since `var()` is a complete calc-value.

#### Why px?
I'm using 0px rather than the typically preferred unit-free 0 because [calc-values must specify a dimension or percentage.](https://www.w3.org/TR/css3-values/#typedef-calc-value) This syntax rule isn't currently enforced by Shed's PostCSS plugins, but current versions of Firefox and Chrome disregard calculations with unit-free values.